### PR TITLE
Fix jumping

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,5 +88,97 @@
         });
       });
     </script>
+
+    <h3>Month Picker with AltField different format than primary field (no last day)</h3>
+    <div id="month">
+      <input type="text" id="monthpicker3" />
+      <input type="text" id="monthpicker4" />
+      <input type="text" id="altmonthpicker1" />
+      <input type="text" id="altmonthpicker2" />
+    </div>
+    
+    <script>
+      $(function() {
+        $("#monthpicker3").datepicker({
+          altField:"#altmonthpicker1",
+          altFormat:"mm/dd/yy",
+          dateFormat:"mm/yy",
+          monthpicker: true
+        });
+        $("#monthpicker4").datepicker({
+          altField:"#altmonthpicker2",
+          altFormat:"mm/dd/yy",
+          dateFormat:"mm/yy",
+          monthpicker: true,
+        });
+      });
+    </script>
+
+    <h3>Quarter Picker with both primary field and AltField lastDay</h3>
+    <div id="quarter">
+      <input type="text" id="quarterpicker3" />
+      <input type="text" id="quarterpicker4" />
+      <input type="text" id="altquarterpicker1" />
+      <input type="text" id="altquarterpicker2" />
+    </div>
+    
+    <script>
+      $(function() {
+        $("#quarterpicker3").datepicker({
+          altField:"#altquarterpicker1",
+          quarterpicker: true
+        });
+        $("#quarterpicker4").datepicker({
+          altField:"#altquarterpicker2",
+          quarterpicker: true,
+          lastDay: "both"
+        });
+      });
+    </script>
+
+    <h3>Month Picker with AltField Last Day</h3>
+    <div id="month">
+      <input type="text" id="monthpicker5" />
+      <input type="text" id="monthpicker6" />
+      <input type="text" id="altmonthpicker3" />
+      <input type="text" id="altmonthpicker4" />
+    </div>
+    
+    <script>
+      $(function() {
+        $("#monthpicker5").datepicker({
+          altField:"#altmonthpicker3",
+          monthpicker: true
+        });
+        $("#monthpicker6").datepicker({
+          altField:"#altmonthpicker4",
+          monthpicker: true,
+          lastDay: "alternate"
+        });
+      });
+    </script>
+
+    <h3>Quarter Picker with primary field last day, altfield regular</h3>
+    <div id="quarter">
+      <input type="text" id="quarterpicker5" />
+      <input type="text" id="quarterpicker6" />
+      <input type="text" id="altquarterpicker3" />
+      <input type="text" id="altquarterpicker4" />
+    </div>
+    
+    <script>
+      $(function() {
+        $("#quarterpicker5").datepicker({
+          altField:"#altquarterpicker3",
+          quarterpicker: true
+        });
+        $("#quarterpicker6").datepicker({
+          altField:"#altquarterpicker4",
+          quarterpicker: true,
+          lastDay: "primary"
+        });
+      });
+    </script>
+
   </body>
 </html>

--- a/jquery.ui.period.datepicker.js
+++ b/jquery.ui.period.datepicker.js
@@ -212,10 +212,12 @@
         val = val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2];
       }
 
-      var dateFormat = this._get(inst, 'dateFormat');
       val = val.split('/');
-      val = this.formatDate(dateFormat,new Date(val[2],val[0]-1,val[1]));
-      inst.input.val(val);
+      
+      inst.currentDay=val[1];
+      inst.currentMonth=val[0]-1;
+      inst.currentYear=val[2];
+      this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
       
       if (eventSelect)
         eventSelect.apply(inst.input, [val, inst]);
@@ -341,10 +343,13 @@
         val = (val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2]);
       }
 
-      var dateFormat = this._get(inst, 'dateFormat');
+
       val = val.split('/');
-      val = this.formatDate(dateFormat,new Date(val[2],val[0]-1,val[1]));
-      inst.input.val(val);
+      
+      inst.currentDay=val[1];
+      inst.currentMonth=val[0]-1;
+      inst.currentYear=val[2];
+      this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
       
       if (eventSelect)
         eventSelect.apply(inst.input, [val, inst]);

--- a/jquery.ui.period.datepicker.js
+++ b/jquery.ui.period.datepicker.js
@@ -205,19 +205,43 @@
     __selectQuarter: function(inst, $obj, obj) {
       var val = $obj.attr("title"),
           eventSelect = obj._get(inst, 'onSelect');
-      
-      if(obj._get(inst, 'lastDay')) {
-        val = val.split('/');
-        val[0] = Math.floor(val[0] / 3) * 3 + 3;
-        val = val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2];
+
+      lastDayOption=obj._get(inst, 'lastDay');      
+
+      if(lastDayOption) {
+        lastdayval = val.split('/');
+        lastdayval[0] = Math.floor(lastdayval[0] / 3) * 3 + 3;
+        lastdayval = lastdayval[0] + '/' + (32 - new Date(lastdayval[2], lastdayval[0] - 1, 32).getDate()) + '/' + lastdayval[2];
       }
 
-      val = val.split('/');
-      
-      inst.currentDay=val[1];
-      inst.currentMonth=val[0]-1;
-      inst.currentYear=val[2];
-      this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+
+      switch(lastDayOption) {
+        case "primary":
+            val = val.split('/');
+            inst.currentDay=val[1];
+            inst.currentMonth=val[0]-1;
+            inst.currentYear=val[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+            inst.input.val(lastdayval);
+            break;
+        case "alternate":
+            lastdayval = lastdayval.split('/');
+            inst.currentDay=lastdayval[1];
+            inst.currentMonth=lastdayval[0]-1;
+            inst.currentYear=lastdayval[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+            inst.input.val(val);
+            break;
+        case true:
+        case "both":
+            val=lastdayval;
+        default:
+            val = val.split('/');
+            inst.currentDay=val[1];
+            inst.currentMonth=val[0]-1;
+            inst.currentYear=val[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+      }
       
       if (eventSelect)
         eventSelect.apply(inst.input, [val, inst]);
@@ -338,18 +362,43 @@
       var val = $obj.attr("title"),
           eventSelect = obj._get(inst, 'onSelect');
 
-      if(obj._get(inst, 'lastDay')) {
-        val = val.split('/');
-        val = (val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2]);
+
+      lastDayOption=obj._get(inst, 'lastDay');
+
+      if(lastDayOption) {
+        lastdayval = val.split('/');
+        lastdayval = (lastdayval[0] + '/' + (32 - new Date(lastdayval[2], lastdayval[0] - 1, 32).getDate()) + '/' + lastdayval[2]);
       }
 
-
-      val = val.split('/');
+      switch(lastDayOption) {
+        case "primary":
+            val = val.split('/');
+            inst.currentDay=val[1];
+            inst.currentMonth=val[0]-1;
+            inst.currentYear=val[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+            inst.input.val(lastdayval);
+            break;
+        case "alternate":
+            lastdayval = lastdayval.split('/');
+            inst.currentDay=lastdayval[1];
+            inst.currentMonth=lastdayval[0]-1;
+            inst.currentYear=lastdayval[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+            inst.input.val(val);
+            break;
+        case true:
+        case "both":
+            val=lastdayval;
+        default:
+            val = val.split('/');
+            inst.currentDay=val[1];
+            inst.currentMonth=val[0]-1;
+            inst.currentYear=val[2];
+            this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
+            
+      }
       
-      inst.currentDay=val[1];
-      inst.currentMonth=val[0]-1;
-      inst.currentYear=val[2];
-      this._selectDate("#"+inst.id,this._formatDate(inst,inst.currentDay,inst.currentMonth,inst.currentYear));
       
       if (eventSelect)
         eventSelect.apply(inst.input, [val, inst]);

--- a/jquery.ui.period.datepicker.js
+++ b/jquery.ui.period.datepicker.js
@@ -212,6 +212,9 @@
         val = val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2];
       }
 
+      var dateFormat = this._get(inst, 'dateFormat');
+      val = val.split('/');
+      val = this.formatDate(dateFormat,new Date(val[2],val[0]-1,val[1]));
       inst.input.val(val);
       
       if (eventSelect)
@@ -338,6 +341,9 @@
         val = (val[0] + '/' + (32 - new Date(val[2], val[0] - 1, 32).getDate()) + '/' + val[2]);
       }
 
+      var dateFormat = this._get(inst, 'dateFormat');
+      val = val.split('/');
+      val = this.formatDate(dateFormat,new Date(val[2],val[0]-1,val[1]));
       inst.input.val(val);
       
       if (eventSelect)

--- a/jquery.ui.period.datepicker.js
+++ b/jquery.ui.period.datepicker.js
@@ -1,7 +1,7 @@
 /**
 * @description  
 *   extends $.datepicker for fw requirements, include week, month, quarter
-* @extends          $.datepicekr
+* @extends          $.datepicker
 * @requires         @.datepicker
 */
 

--- a/jquery.ui.period.datepicker.js
+++ b/jquery.ui.period.datepicker.js
@@ -179,8 +179,9 @@
       }
       tbody += '</tr>';
       var $tbody = $(tbody);
-      $tbody.find("a.ui-state-default").click(function() {
+      $tbody.find("a.ui-state-default").click(function(e) {
         obj.__selectQuarter(inst, $(this), obj);
+        e.preventDefault();
       });
       $html.find("table").css("marginTop", "5px").children('tbody').append($tbody);
       return $html.children();
@@ -315,8 +316,9 @@
         tbody += '</tr>';
       }
       var $tbody = $(tbody);
-      $tbody.find("a.ui-state-default").click(function() {
+      $tbody.find("a.ui-state-default").click(function(e) {
         obj.__selectMonth(inst, $(this), obj);
+        e.preventDefault();
       });
       $html.find("table").css("marginTop", "5px").children('tbody').append($tbody);
       return $html.children();


### PR DESCRIPTION
When a user selects a date using the quarter or month picker, the page would jump to the top following the # href. I fixed the click event to disable this behavior so that when a user clicks on the date, the scroll stays exactly where you clicked it.
